### PR TITLE
allow spurius parameters in QwtPlotDict __init__

### DIFF
--- a/qwt/plot.py
+++ b/qwt/plot.py
@@ -110,7 +110,7 @@ class QwtPlotDict(object):
         :py:meth:`QwtPlotItem.z()`
     """
 
-    def __init__(self):
+    def __init__(self, *_):
         self.__data = QwtPlotDict_PrivateData()
 
     def setAutoDelete(self, autoDelete):
@@ -300,8 +300,7 @@ class QwtPlot(QFrame, QwtPlotDict):
                 "%s() takes 0, 1 or 2 argument(s) (%s given)"
                 % (self.__class__.__name__, len(args))
             )
-        QwtPlotDict.__init__(self)
-        QFrame.__init__(self, parent)
+        super().__init__(parent)
 
         self.__layout_state = None
 


### PR DESCRIPTION
`QwtPlot` extends `QFrame` and `QwtPlotDict`.
`QFrame`'s `__init__` expect up to 2 parameters, and - at least with current pyside - supports cooperative multiple inheritance. this means that internally `QFrame.__init__` will call `QwtPlotDict.__init__`, forwarding all the parameters.

fixes: #74 

a (simplified) simulation of the problem:

current:
```python
class QwtPlotDict:
    def __init__(self):
        print(f'QwtPlotDict.__init__()')

class QFrame:
    def __init__(self, *args):
        print(f'QFrame.__init__({args})')
        super().__init__(*args)

class QwtPlot(QFrame, QwtPlotDict):
    def __init__(self, parent = None):
        print(f'QwtPlot.__init__({parent})')
        QwtPlotDict.__init__(self)
        QFrame.__init__(self, parent)

plot = QwtPlot()

```

with fix:
```python
class QwtPlotDict:
    def __init__(self, *_):
        print(f'QwtPlotDict.__init__()')

class QFrame:
    def __init__(self, *args):
        print(f'QFrame.__init__({args})')
        super().__init__(*args)

class QwtPlot(QFrame, QwtPlotDict):
    def __init__(self, parent = None):
        print(f'QwtPlot.__init__({parent})')
        super().__init__(parent)

plot = QwtPlot()
````