### PR TITLE
Fix call to ScaleEngine.autoScale

### DIFF
--- a/qwt/plot.py
+++ b/qwt/plot.py
@@ -954,7 +954,7 @@ class QwtPlot(QFrame):
                 d.isValid = False
                 minValue = intv_i.minValue()
                 maxValue = intv_i.maxValue()
-                d.scaleEngine.autoScale(d.maxMajor, minValue, maxValue, stepSize)
+                minValue, maxValue, stepSize = d.scaleEngine.autoScale(d.maxMajor, minValue, maxValue, stepSize)
             if not d.isValid:
                 d.scaleDiv = d.scaleEngine.divideScale(
                     minValue, maxValue, d.maxMajor, d.maxMinor, stepSize


### PR DESCRIPTION
[The original `QwtScaleEngine.autoScale` member function](https://sourceforge.net/p/qwt/code/HEAD/tree/trunk/qwt/src/qwt_scale_engine.cpp#l531) mutated the passed values in-place, but this was missed when the code was translated to Python, where `autoScale` returns the new values as a tuple.