### PR TITLE
Fix autoScale in scale_engine.py

### DIFF
--- a/qwt/scale_engine.py
+++ b/qwt/scale_engine.py
@@ -674,10 +674,7 @@ class QwtLogScaleEngine(QwtScaleEngine):
             linearInterval = linearInterval.limited(LOG_MIN, LOG_MAX)
 
             if linearInterval.maxValue() / linearInterval.minValue() < logBase:
-                if stepSize < 0.0:
-                    stepSize = -math.log(abs(stepSize), logBase)
-                else:
-                    stepSize = math.log(stepSize, logBase)
+                stepSize = 0.0
                 return x1, x2, stepSize
 
         logRef = 1.0

--- a/qwt/scale_engine.py
+++ b/qwt/scale_engine.py
@@ -674,6 +674,8 @@ class QwtLogScaleEngine(QwtScaleEngine):
             linearInterval = linearInterval.limited(LOG_MIN, LOG_MAX)
 
             if linearInterval.maxValue() / linearInterval.minValue() < logBase:
+                # The min / max interval is too short to be represented as a log scale. 
+                # Set the step to 0, so that a new step is calculated and a linear scale is used.
                 stepSize = 0.0
                 return x1, x2, stepSize
 


### PR DESCRIPTION
The [original code in `qwt_scale_engine.cpp`](https://sourceforge.net/p/qwt/code/HEAD/tree/trunk/qwt/src/qwt_scale_engine.cpp#l826) was setting the `stepSize` to zero.

Not sure the reason why this was changed, perhaps by accident?

Opening this for your consideration. :+1: 