### PR TITLE
Fix: legend now showing up when enabled later

### DIFF
--- a/qwt/plot.py
+++ b/qwt/plot.py
@@ -1560,9 +1560,9 @@ class QwtPlot(QFrame):
                 if self.__data.legend.parent() is not self:
                     self.__data.legend.setParent(self)
 
-                self.blockSignals(True)
+                self.legendDataChanged.disconnect(self.updateLegendItems)
                 self.updateLegend()
-                self.blockSignals(False)
+                self.legendDataChanged.connect(self.updateLegendItems)
 
                 lpos = self.__data.layout.legendPosition()
 


### PR DESCRIPTION
In our code base we had code which does:

1. Create a plot
2. Attach a curve
3. Enable legend

This worked in Qwt 5, but with PythonQwt the legend was not showing up. Switching the order of 2 and 3 caused the legend to then appear.

Debugging I found out blocking signals around `updateLegend` inside `insertLegend` was the culprit. The original source code [does not block signals](https://sourceforge.net/p/qwt/code/HEAD/tree/trunk/qwt/src/qwt_plot.cpp#l943), but calls [`qwtEnableLegendItems`](https://sourceforge.net/p/qwt/code/HEAD/tree/trunk/qwt/src/qwt_plot.cpp#l27), which only disconnects/connects `updateLegendItems`.

Doing the same here fixed the issue: now enabling the legend in a plot which already has curves causes the legend to appear correctly.