### PR TITLE
Fix `QRectF` to `QRect` cast in `QwtPainterClass.drawBackground`

### DIFF
--- a/qwt/painter.py
+++ b/qwt/painter.py
@@ -393,7 +393,7 @@ class QwtPainterClass(object):
         if widget.testAttribute(Qt.WA_StyledBackground):
             opt = QStyleOption()
             opt.initFrom(widget)
-            opt.rect = rect
+            opt.rect = rect.toRect()
             widget.style().drawPrimitive(QStyle.PE_Widget, opt, painter, widget)
         else:
             brush = widget.palette().brush(widget.backgroundRole())


### PR DESCRIPTION
When calling `QwtPlotRenderer.renderTo(...)`, it internally calls `drawBackground()` where a `QRectF` is being assigned to `QStyleOption.rect`, which expects a `QRect`. This leads to an error: `QRectF cannot be converted to QRect in this context`.  

The fix was explicitly convert the `QRectF` to a `QRect`  before assignment. 