### PR TITLE
[FIX] Legend icon being rendered incorrectly

### DIFF
--- a/qwt/null_paintdevice.py
+++ b/qwt/null_paintdevice.py
@@ -273,7 +273,7 @@ class QwtNullPaintDevice(QPaintDevice):
                 / self.metric(QPaintDevice.PdmDpiY)
             )
         else:
-            value = 0
+            value = super(QwtNullPaintDevice, self).metric(deviceMetric)
         return value
 
     def drawRects(self, rects, rectCount):


### PR DESCRIPTION
This fixes the problem described in issue [#104](https://github.com/PlotPyStack/PythonQwt/issues/104). The code was returning **0** as a fallback for the metric. I just modified it to use the original Qt method.

Before the fix: 
<img width="597" height="404" alt="image" src="https://github.com/user-attachments/assets/e421bdf0-ec94-42d3-82a3-3aaf6d827cfb" />

After the fix:
<img width="596" height="400" alt="image" src="https://github.com/user-attachments/assets/bc1c956f-acf8-4fa1-806a-33eca35e82bc" />

