### PR TITLE
Fix legend icon not rendering correctly due to wrong scaled dpr metric

### DIFF
--- a/qwt/null_paintdevice.py
+++ b/qwt/null_paintdevice.py
@@ -275,7 +275,7 @@ class QwtNullPaintDevice(QPaintDevice):
         elif deviceMetric == QPaintDevice.PdmDevicePixelRatio:
             value = 1
         elif deviceMetric == QPaintDevice.PdmDevicePixelRatioScaled:
-            value = 1
+            value = 0x10000
         else:
             value = super(QwtNullPaintDevice, self).metric(deviceMetric)
         return value


### PR DESCRIPTION
Fix QwtNullPaintDevice.metric() returning the wrong value for PdmDevicePixelRatioScaled, which caused legend icons to collapse to a degenerate size.

This is similar to [#104](https://github.com/PlotPyStack/PythonQwt/issues/104), but with different causes.

Qt stores the device pixel ratio as a fixed-point integer scaled by QPaintDevice::devicePixelRatioFScale() (which is 0x10000 = 65536). This is how Qt represents a fractional DPR (e.g. 1.25, 1.5, 2.0) while keeping metric()'s return type as int.

So returning 1 for PdmDevicePixelRatioScaled means DPR interpreted as 1/65536 ≈ 0.0000153 → collapsed.

This also prevents the "Device has no metric information" warning.

Before the fix: 

<img width="556" height="394" alt="image" src="https://github.com/user-attachments/assets/899ad5cb-6893-40e4-ad68-24b96e4d0dcd" />

After the fix:

<img width="556" height="371" alt="image" src="https://github.com/user-attachments/assets/23db9dc5-4ce0-4a32-a3f3-65f94bc6cdaf" />

